### PR TITLE
Fixing auth by token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ github-test.rb
 examples/active_example.rb
 examples/.DS_Store
 .idea
+.rvmrc

--- a/.rvmrc
+++ b/.rvmrc
@@ -1,5 +1,0 @@
-if [[ -s "~/.rvm/environments/ruby-1.9.2-p180@gattica" ]] ; then
-  . "~/.rvm/environments/ruby-1.9.2-pl180@gattica"
-else
-  rvm --create use "1.9.2@gattica"
-fi

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+This Fork
+=======
+Deviantech's fork of the Gattica gem has the following modifications:
+
+* Authentication by token actually works
+
+-------
+
 Gattica
 =======
 Gattica is an easy to use Gem for getting data from the Google Analytics API.  

--- a/gattica.gemspec
+++ b/gattica.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
     "README.md"
   ]
   s.files = [
-    ".rvmrc",
     "Gemfile",
     "LICENSE",
     "README.md",

--- a/lib/gattica/engine.rb
+++ b/lib/gattica/engine.rb
@@ -251,7 +251,7 @@ module Gattica
       @http = Net::HTTP.new(Settings::SERVER, port)
       @http.use_ssl = Settings::USE_SSL
       @http.set_debug_output $stdout if @options[:debug]
-      @http.read_timeout = @options[:timeout] if defined? @options[:timeout]
+      @http.read_timeout = @options[:timeout] if @options[:timeout]
     end
 
     # Sets instance variables from options given during initialization and
@@ -268,12 +268,12 @@ module Gattica
     # If the authorization is a email and password then create User objects
     # or if it's a previous token, use that.  Else, raise exception.
     def check_init_auth_requirements
-      if ((defined? @options[:email]) && (defined? @options[:password]))
+      if @options[:token].to_s.length > 200 # Not sure actual required length, but mine's 267
+        self.token = @options[:token]
+      elsif @options[:email] && @options[:password]
         @user = User.new(@options[:email], @options[:password])
         @auth = Auth.new(@http, user)
         self.token = @auth.tokens[:auth]
-      elsif (defined? @options[:token])
-        self.token = @options[:token]
       else
         raise GatticaError::NoLoginOrToken, 'An email and password or an authentication token is required to initialize Gattica.'
       end


### PR DESCRIPTION
Hi Chris,

I'm not sure if you're the current maintainer (Google directed me to http://rubydoc.info/github/chrisle/gattica/master/frames, which pointed to your github repo), but I fixed this there before I realized how scattered the network is for Gattica.

Anyway, if this is of interest to you, I made a few changes so logging in via :token works now.  

Cheers,
-Kali
