### PR TITLE
nil exception for ruby 1.9.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,21 @@
+PATH
+  remote: .
+  specs:
+    gattica (0.5.1)
+      hpricot
+      test-unit
+
+GEM
+  remote: http://rubygems.org/
+  specs:
+    hpricot (0.8.6)
+    rake (0.9.2.2)
+    test-unit (2.4.5)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  gattica!
+  rake
+  test-unit

--- a/gattica.gemspec
+++ b/gattica.gemspec
@@ -51,18 +51,15 @@ Gem::Specification.new do |s|
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<gattica>, [">= 0"])
       s.add_runtime_dependency(%q<test-unit>, [">= 0"])
       s.add_development_dependency(%q<rake>, [">= 0"])
       s.add_runtime_dependency(%q<hpricot>, [">= 0"])
     else
-      s.add_dependency(%q<gattica>, [">= 0"])
       s.add_dependency(%q<test-unit>, [">= 0"])
       s.add_dependency(%q<rake>, [">= 0"])
       s.add_dependency(%q<hpricot>, [">= 0"])
     end
   else
-    s.add_dependency(%q<gattica>, [">= 0"])
     s.add_dependency(%q<test-unit>, [">= 0"])
     s.add_dependency(%q<rake>, [">= 0"])
     s.add_dependency(%q<hpricot>, [">= 0"])

--- a/lib/gattica/auth.rb
+++ b/lib/gattica/auth.rb
@@ -20,7 +20,8 @@ module Gattica
       options = OPTIONS.merge(user.to_h)
       options.extend HashExtensions
       
-      response, data = http.post(SCRIPT_NAME, options.to_query, HEADERS)
+      response = http.post(SCRIPT_NAME, options.to_query, HEADERS)
+      data = response.body ||= ''
       if response.code != '200'
         case response.code
         when '403'


### PR DESCRIPTION
Fixed "undefined method `split' for nil:NilClass" exception for init under ruby 1.9.3
