### PR TITLE
Metric Values should be float in order to handle percentage values

### DIFF
--- a/lib/gattica/data_point.rb
+++ b/lib/gattica/data_point.rb
@@ -20,7 +20,7 @@ module Gattica
         { dimension.attributes['name'].split(':').last.to_sym => dimension.attributes['value'].split(':').last }
       end
       @metrics = xml.search('dxp:metric').collect do |metric|
-        { metric.attributes['name'].split(':').last.to_sym => metric.attributes['value'].split(':').last.to_i }
+        { metric.attributes['name'].split(':').last.to_sym => metric.attributes['value'].split(':').last.to_f }
       end
     end
     


### PR DESCRIPTION
Hi!

I came across the issue, that I could not use any percentage values from the goals defined in GA (e.g. ConversionRate), cause they're converted to integer.
Generally I think it would be better, to return them as float.

Would be nice, if you could integrate this! Thanks anyway for this nice gem :)

Best,
Daniel
