### PR TITLE
Add verify_ssl option

### DIFF
--- a/lib/gattica/engine.rb
+++ b/lib/gattica/engine.rb
@@ -16,6 +16,7 @@ module Gattica
     # +:profile_id+::   Use this Google Analytics profile_id (default is nil)
     # +:timeout+::      Set Net:HTTP timeout in seconds (default is 300)
     # +:token+::        Use an authentication token you received before
+    # +:verify_ssl+::   Verify SSL connection (default is true)
     def initialize(options={})
       @options = Settings::DEFAULT_OPTIONS.merge(options)
       handle_init_options(@options)
@@ -262,6 +263,7 @@ module Gattica
       port = Settings::USE_SSL ? Settings::SSL_PORT : Settings::NON_SSL_PORT
       @http = Net::HTTP.new(server, port)
       @http.use_ssl = Settings::USE_SSL
+      @http.verify_mode = @options[:verify_ssl] ? Settings::VERIFY_SSL_MODE : Settings::NO_VERIFY_SSL_MODE
       @http.set_debug_output $stdout if @options[:debug]
       @http.read_timeout = @options[:timeout] if @options[:timeout]
     end

--- a/lib/gattica/settings.rb
+++ b/lib/gattica/settings.rb
@@ -4,6 +4,8 @@ module Gattica
     USE_SSL = true
     SSL_PORT = 443
     NON_SSL_PORT = 80
+    NO_VERIFY_SSL_MODE = OpenSSL::SSL::VERIFY_NONE
+    VERIFY_SSL_MODE = OpenSSL::SSL::VERIFY_PEER
 
     TIMEOUT = 100
 
@@ -23,7 +25,8 @@ module Gattica
         :profile_id => nil,
         :debug => false,
         :headers => {},
-        :logger => Logger.new(STDOUT)
+        :logger => Logger.new(STDOUT),
+        :verify_ssl => true
     }
 
     FILTER_METRIC_OPERATORS = %w{ == != > < >= <= }


### PR DESCRIPTION
I have added an option to those accepted by Gattica#new, :verify_ssl, that sets the SSL verify mode on the Net::HTTP connection. 
