### PR TITLE
updated path to segments

### DIFF
--- a/lib/gattica/engine.rb
+++ b/lib/gattica/engine.rb
@@ -87,6 +87,7 @@ module Gattica
 
     def segments
       if @user_segments.nil?
+        create_http_connection('www.googleapis.com')
         response = do_http_get("/analytics/v2.4/management/segments?max-results=10000")
         xml = Hpricot(response)
         @user_segments = xml.search("dxp:segment").collect { |s| 


### PR DESCRIPTION
once upon a time it looks like the segments resource was accessible from google.com. I discovered it was 404'ing so I updated the #segments method to create a connection to www.googleapis.com before fetching
