### PR TITLE
Add support for using a Google API key.

### DIFF
--- a/lib/gattica/engine.rb
+++ b/lib/gattica/engine.rb
@@ -16,6 +16,7 @@ module Gattica
     # +:profile_id+::   Use this Google Analytics profile_id (default is nil)
     # +:timeout+::      Set Net:HTTP timeout in seconds (default is 300)
     # +:token+::        Use an authentication token you received before
+    # +:api_key+::      The Google API Key for your project
     # +:verify_ssl+::   Verify SSL connection (default is true)
     def initialize(options={})
       @options = Settings::DEFAULT_OPTIONS.merge(options)
@@ -153,12 +154,19 @@ module Gattica
 
     ######################################################################
     private
+    
+    # Add the Google API key to the query string, if one is specified in the options.
+    
+    def add_api_key(query_string)
+      query_string += "&key=#{@options[:api_key]}" if @options[:api_key]
+      query_string
+    end
 
     # Does the work of making HTTP calls and then going through a suite of tests on the response to make
     # sure it's valid and not an error
 
     def do_http_get(query_string)
-      response = @http.get(query_string, @headers)
+      response = @http.get(add_api_key(query_string), @headers)
 
       # error checking
       if response.code != '200'

--- a/lib/gattica/settings.rb
+++ b/lib/gattica/settings.rb
@@ -22,6 +22,7 @@ module Gattica
         :email => nil,        # eg: 'email@gmail.com'
         :password => nil,     # eg: '$up3r_$ekret'
         :token => nil,
+        :api_key => nil,
         :profile_id => nil,
         :debug => false,
         :headers => {},


### PR DESCRIPTION
Allow a Google API key to be used for requests, which greatly raises the allowable rate limits. The rate limits for anonymous requests are pretty low.

This addresses Issue #17.
