### PR TITLE
Add http proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,17 @@ Google expects a special header in all HTTP requests called 'Authorization'.  Ga
         :headers => {'My-Special-Header':'my_custom_value'}
     })
         
+Using http proxy
+-----------------
+
+You can set http proxy settings when you instantiate the Gattica object:
+
+    ga = Gattica.new({ 
+        :email => 'email@gmail.com', 
+        :password => 'password',
+        :http_proxy => { :host => 'proxy.example.com', :port => 8080, :user => 'username', :password => 'password' }
+    })
+    
 <hr />
 
 History

--- a/lib/gattica/engine.rb
+++ b/lib/gattica/engine.rb
@@ -270,11 +270,20 @@ module Gattica
 
     def create_http_connection(server)
       port = Settings::USE_SSL ? Settings::SSL_PORT : Settings::NON_SSL_PORT
-      @http = Net::HTTP.new(server, port)
+      @http = @options[:http_proxy].any? ? http_proxy.new(server, port) : Net::HTTP.new(server, port)
       @http.use_ssl = Settings::USE_SSL
       @http.verify_mode = @options[:verify_ssl] ? Settings::VERIFY_SSL_MODE : Settings::NO_VERIFY_SSL_MODE
       @http.set_debug_output $stdout if @options[:debug]
       @http.read_timeout = @options[:timeout] if @options[:timeout]
+    end
+
+    def http_proxy
+      proxy_host = @options[:http_proxy][:host]
+      proxy_port = @options[:http_proxy][:port]
+      proxy_user = @options[:http_proxy][:user]
+      proxy_pass = @options[:http_proxy][:password]
+
+      Net::HTTP::Proxy(proxy_host, proxy_port, proxy_user, proxy_pass)
     end
 
     # Sets instance variables from options given during initialization and

--- a/lib/gattica/settings.rb
+++ b/lib/gattica/settings.rb
@@ -27,7 +27,8 @@ module Gattica
         :debug => false,
         :headers => {},
         :logger => Logger.new(STDOUT),
-        :verify_ssl => true
+        :verify_ssl => true,
+        :http_proxy => {}
     }
 
     FILTER_METRIC_OPERATORS = %w{ == != > < >= <= }


### PR DESCRIPTION
Hello, thanks for supporting this useful gem!

This pull request adds http proxy support with this configs:

``` ruby
ga = Gattica.new({ 
    ...
    :http_proxy => { :host => 'proxy.example.com', :port => 8080, :user => 'username', :password => 'password' }
})
```

I've tried to add some tests around this feature, i.e. something like:

``` ruby
def test_setting_http_proxy
  ga = Gattica.new((GatticaTest::DEFAULT_AUTH).merge!(:http_proxy => { host: "proxy.example.com", port: "8080", user: "user", password: "password" }))
  http = ga.instance_variable_get('@http')
  assert http.proxy_host == "proxy.example.com", "proxy_host should be 'proxy.example.com'"
  assert http.proxy_port == "8080", "proxy_port should be '8080'"
  assert http.proxy_user == "user", "proxy_user should be 'user'"
  assert http.proxy_pass == "password", "proxy_user should be 'password'"
end
```

but since Gattica.new starts real http connection this approach didn't really work out.. so I left out the tests for now, but the code is very simple and i've tested it manually in couple environments.
