### PR TITLE
No need to split dimension/metic values on a colon

### DIFF
--- a/lib/gattica/data_point.rb
+++ b/lib/gattica/data_point.rb
@@ -17,10 +17,10 @@ module Gattica
       @updated = DateTime.parse(xml.at('updated').inner_html)
       @title = xml.at('title').inner_html
       @dimensions = xml.search('dxp:dimension').collect do |dimension|
-        { dimension.attributes['name'].split(':').last.to_sym => dimension.attributes['value'].split(':').last }
+        { dimension.attributes['name'].split(':').last.to_sym => dimension.attributes['value'] }
       end
       @metrics = xml.search('dxp:metric').collect do |metric|
-        { metric.attributes['name'].split(':').last.to_sym => metric.attributes['value'].split(':').last.to_f }
+        { metric.attributes['name'].split(':').last.to_sym => metric.attributes['value'].to_f }
       end
     end
     


### PR DESCRIPTION
I tracked down an issue I was having where URLs which contained a colon character were not being properly included in the Gattica results.  For example, this crazy URL from our Google Analytics account:

/stories/Rida-Asim-Wins-Scholastic-Regional-Art-and-Writing-Award/209582?fb_action_ids=10151390356368347&fb_action_types=og.likes&fb_source=other_multiline&action_object_map={"10151390356368347":524248140960991}&action_type_map={"10151390356368347":"og.likes"}&action_ref_map=[]

...was being returned as: "og.likes"}&action_ref_map=[]

This was due to the following line in the DataPoint model's initializer:

{ dimension.attributes['name'].split(':').last.to_sym => dimension.attributes['value'].split(':').last }

I understand why you are splitting the dimension/metic names on a colon but I do not believe that you have to split the values.  For example you would want to split the name ga:pagePath to get pagePath but not the value: /foo/bar?baz=123.  Let me know if I'm wrong about this.
