### PR TITLE
Fix link to blog post in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Features
 * Returns data as: hash, json, CSV
 
 [How to export Google Analytics data using Ruby](
-http://www.seerinteractive.com/blog/google-analytics-data-export-api-with-rubygattica/2011/02/22/) (Links to my blog post on [Seer Interactive](http://www.seerinteractive.com))
+http://www.seerinteractive.com/blog/google-analytics-data-export-api-with-rubygattica) (Links to my blog post on [Seer Interactive](http://www.seerinteractive.com))
 
 <hr />
 


### PR DESCRIPTION
Hi there,

I just clicked on the blog post link in the `README` and it showed an RSS feed for the blog. I eventually found it with some trial and error. Pull request attached for your consideration!
- http://www.seerinteractive.com/blog/google-analytics-data-export-api-with-rubygattica/2011/02/22/ :heavy_multiplication_x:
- http://www.seerinteractive.com/blog/google-analytics-data-export-api-with-rubygattica/2011/02/22 :heavy_multiplication_x:
- http://www.seerinteractive.com/blog/google-analytics-data-export-api-with-rubygattica/ :heavy_multiplication_x:
- http://www.seerinteractive.com/blog/google-analytics-data-export-api-with-rubygattica :heavy_check_mark: 

Cheers,
  Lee :beers:
