### PR TITLE
Bugfix in expressions! SSL certs support

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,17 @@ You can set http proxy settings when you instantiate the Gattica object:
         :password => 'password',
         :http_proxy => { :host => 'proxy.example.com', :port => 8080, :user => 'username', :password => 'password' }
     })
+
+Specifying SSL certificates directory
+-----------------
+
+You can set ssl certificates directory path when you instantiate the Gattica object:
+
+    ga = Gattica.new({ 
+        :email => 'email@gmail.com', 
+        :password => 'password',
+        :ssl_ca_path => '/usr/lib/ssl/certs'
+    })
     
 <hr />
 

--- a/lib/gattica.rb
+++ b/lib/gattica.rb
@@ -8,6 +8,7 @@ require 'logger'
 require 'rubygems'
 require 'hpricot'
 require 'yaml'
+require 'openssl'
 
 require 'gattica/engine'
 require 'gattica/settings'

--- a/lib/gattica/engine.rb
+++ b/lib/gattica/engine.rb
@@ -225,7 +225,7 @@ module Gattica
         output += '&filters=' + args[:filters].collect do |filter|
           match, name, operator, expression = *filter.match(/^(\w*)\s*([=!<>~@]*)\s*(.*)$/)           # splat the resulting Match object to pull out the parts automatically
           unless name.empty? || operator.empty? || expression.empty?                      # make sure they all contain something
-            "ga:#{name}#{CGI::escape(operator.gsub(/ /,''))}#{CGI::escape(expression)}"   # remove any whitespace from the operator before output
+            "ga:#{name}#{CGI::escape(operator.gsub(/ /,''))}#{CGI::escape(expression.gsub(',', '\,'))}"   # remove any whitespace from the operator before output and escape commas in expression
           else
             raise GatticaError::InvalidFilter, "The filter '#{filter}' is invalid. Filters should look like 'browser == Firefox' or 'browser==Firefox'"
           end

--- a/lib/gattica/engine.rb
+++ b/lib/gattica/engine.rb
@@ -18,6 +18,7 @@ module Gattica
     # +:token+::        Use an authentication token you received before
     # +:api_key+::      The Google API Key for your project
     # +:verify_ssl+::   Verify SSL connection (default is true)
+    # +:ssl_ca_path+::  PATH TO SSL CERTIFICATES to see this run on command line:(openssl version -a) ubuntu path eg:"/usr/lib/ssl/certs"
     def initialize(options={})
       @options = Settings::DEFAULT_OPTIONS.merge(options)
       handle_init_options(@options)
@@ -275,6 +276,9 @@ module Gattica
       @http.verify_mode = @options[:verify_ssl] ? Settings::VERIFY_SSL_MODE : Settings::NO_VERIFY_SSL_MODE
       @http.set_debug_output $stdout if @options[:debug]
       @http.read_timeout = @options[:timeout] if @options[:timeout]
+      if (@options[:ssl_ca_path] && File.directory?(@options[:ssl_ca_path]) && @http.use_ssl?)
+        @http.ca_path = @options[:ssl_ca_path]
+      end
     end
 
     def http_proxy

--- a/lib/gattica/settings.rb
+++ b/lib/gattica/settings.rb
@@ -28,6 +28,7 @@ module Gattica
         :headers => {},
         :logger => Logger.new(STDOUT),
         :verify_ssl => true,
+        :ssl_ca_path => nil,
         :http_proxy => {}
     }
 


### PR DESCRIPTION
Commas were considerated OR's when i was passing page titles with commas. 
Support for ssl certificates path. 
