### PR TITLE
Auth version not defined ?

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,8 +523,3 @@ Maintainer history
   * [Rob Cameron](https://github.com/activenetwork/gattica) (2010)
   * [Mike Rumble](https://github.com/rumble/gattica) (2010)
   * [Chris Le](https://github.com/chrisle/gattica) (Current)
-  
-
-
-[![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/waghanza/gattica/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
-

--- a/README.md
+++ b/README.md
@@ -524,3 +524,7 @@ Maintainer history
   * [Mike Rumble](https://github.com/rumble/gattica) (2010)
   * [Chris Le](https://github.com/chrisle/gattica) (Current)
   
+
+
+[![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/waghanza/gattica/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
+

--- a/README.md
+++ b/README.md
@@ -19,6 +19,15 @@ Here are bare basics to get you up and running.
 
 Installation
 ------------
+
+### Standalone app ###
+
+```ruby
+gem install "chrisle-gattica"
+```
+
+### Rake based app ###
+
 Add Gattica to your Gemfile
 
     gem 'gattica', :git => 'git://github.com/chrisle/gattica.git'


### PR DESCRIPTION
Hi,

I'm still a newbie in ruby (not understanding all the vm implication).
I want to retrieve my google analitycs info using gattica

``` ruby
require 'rubygems'
require 'gattica'

ga = Gattica.new({  
  :email => $GA_ACCOUNT,
  :password => $GA_PASSWD,
  :profile_id => $GA_PROFILE})
```

I've the current error message

``` ruby
/usr/local/share/gems/gems/cannikin-gattica-0.4.0/lib/gattica/auth.rb:14:in `<class:Auth>': uninitialized constant Gattica::Auth::VERSION (NameError)
    from /usr/local/share/gems/gems/cannikin-gattica-0.4.0/lib/gattica/auth.rb:8:in `<module:Gattica>'
    from /usr/local/share/gems/gems/cannikin-gattica-0.4.0/lib/gattica/auth.rb:4:in `<top (required)>'
    from /usr/local/share/ruby/site_ruby/rubygems/core_ext/kernel_require.rb:45:in `require'
    from /usr/local/share/ruby/site_ruby/rubygems/core_ext/kernel_require.rb:45:in `require'
    from /usr/local/share/gems/gems/cannikin-gattica-0.4.0/lib/gattica.rb:18:in `<top (required)>'
    from /usr/local/share/ruby/site_ruby/rubygems/core_ext/kernel_require.rb:110:in `require'
    from /usr/local/share/ruby/site_ruby/rubygems/core_ext/kernel_require.rb:110:in `rescue in require'
    from /usr/local/share/ruby/site_ruby/rubygems/core_ext/kernel_require.rb:35:in `require'
    from analitycs.rb:2:in `<main>'
```

How can I solve this ?

Regards,
