### PR TITLE
Upgrade auth 0601

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ github-test.rb
 examples/active_example.rb
 examples/.DS_Store
 .idea
+.ruby-version

--- a/gattica.gemspec
+++ b/gattica.gemspec
@@ -53,18 +53,15 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<gattica>, [">= 0"])
-      s.add_runtime_dependency(%q<test-unit>, [">= 0"])
       s.add_development_dependency(%q<rake>, [">= 0"])
       s.add_runtime_dependency(%q<hpricot>, [">= 0"])
     else
       s.add_dependency(%q<gattica>, [">= 0"])
-      s.add_dependency(%q<test-unit>, [">= 0"])
       s.add_dependency(%q<rake>, [">= 0"])
       s.add_dependency(%q<hpricot>, [">= 0"])
     end
   else
     s.add_dependency(%q<gattica>, [">= 0"])
-    s.add_dependency(%q<test-unit>, [">= 0"])
     s.add_dependency(%q<rake>, [">= 0"])
     s.add_dependency(%q<hpricot>, [">= 0"])
   end

--- a/gattica.gemspec
+++ b/gattica.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
     "gattica.gemspec",
     "lib/gattica.rb",
     "lib/gattica/account.rb",
+    "lib/gattica/asserter.rb",
     "lib/gattica/auth.rb",
     "lib/gattica/convertible.rb",
     "lib/gattica/data_point.rb",
@@ -55,15 +56,18 @@ Gem::Specification.new do |s|
       s.add_runtime_dependency(%q<gattica>, [">= 0"])
       s.add_development_dependency(%q<rake>, [">= 0"])
       s.add_runtime_dependency(%q<hpricot>, [">= 0"])
+      s.add_runtime_dependency(%q<google-api-client>, ["~> 0.7.1"])
     else
       s.add_dependency(%q<gattica>, [">= 0"])
       s.add_dependency(%q<rake>, [">= 0"])
       s.add_dependency(%q<hpricot>, [">= 0"])
+      s.add_dependency(%q<google-api-client>, ["~> 0.7.1"])
     end
   else
     s.add_dependency(%q<gattica>, [">= 0"])
     s.add_dependency(%q<rake>, [">= 0"])
     s.add_dependency(%q<hpricot>, [">= 0"])
+    s.add_dependency(%q<google-api-client>, ["~> 0.7.1"])
   end
 end
 

--- a/lib/gattica.rb
+++ b/lib/gattica.rb
@@ -20,16 +20,17 @@ require 'gattica/account'
 require 'gattica/data_set'
 require 'gattica/data_point'
 require 'gattica/segment'
+require 'gattica/asserter'
 
 # Gattica is a Ruby library for talking to the Google Analytics API.
 # Please see the README for usage docs.
 module Gattica
-  
+
   VERSION = '0.5.1'
-  
+
   # Creates a new instance of Gattica::Engine
   def self.new(*args)
     Engine.new(*args)
   end
-  
+
 end

--- a/lib/gattica/asserter.rb
+++ b/lib/gattica/asserter.rb
@@ -1,0 +1,29 @@
+module Gattica
+
+  # Represents a user to be authenticated by GA
+
+  class Asserter
+    attr_accessor :email, :pkcs12_path
+
+    def initialize(email,pkcs12_path)
+      @email = email
+      @pkcs12_path = pkcs12_path
+      validate
+    end
+
+    def access_token
+      @access_token ||= begin
+        key = ::Google::APIClient::PKCS12.load_key(pkcs12_path, 'notasecret')
+        asserter = ::Google::APIClient::JWTAsserter.new(email, 'https://www.googleapis.com/auth/analytics', key)
+        asserter.authorize.access_token
+      end
+    end
+
+    private
+    # Determine whether or not this is a valid user
+    def validate
+      raise GatticaError::InvalidEmail, "The email address '#{@email}' is not valid" if not @email.match(/^(?:[_a-z0-9-]+)(\.[_a-z0-9-]+)*@([a-z0-9-]+)(\.[a-zA-Z0-9\-\.]+)*(\.[a-z]{2,4})$/i)
+      raise GatticaError::InvalidPkcs12Path, "The pkcs12_path cannot be blank" if @pkcs12_path.empty? || @pkcs12_path.nil? || (@pkcs12_path && !File.exists?(@pkcs12_path))
+    end
+  end
+end

--- a/lib/gattica/auth.rb
+++ b/lib/gattica/auth.rb
@@ -2,11 +2,11 @@ require 'net/http'
 require 'net/https'
 
 module Gattica
-  
+
   # Authenticates a user against the Google Client Login system
-  
+
   class Auth
-    
+
     include Convertible
 
     SCRIPT_NAME = '/accounts/ClientLogin'
@@ -14,12 +14,12 @@ module Gattica
     OPTIONS = { :source => 'gattica', :service => 'analytics' }                                    # Google asks that you provide the name of your app as a 'source' parameter in your POST
 
     attr_reader :tokens
-  
+
     # Try to authenticate the user
     def initialize(http, user)
       options = OPTIONS.merge(user.to_h)
       options.extend HashExtensions
-      
+
       response, data = http.post(SCRIPT_NAME, options.to_query, HEADERS)
       if response.code != '200'
         case response.code
@@ -29,18 +29,19 @@ module Gattica
           raise GatticaError::UnknownAnalyticsError, response.body + " (status code: #{response.code})"
         end
       end
+      data = response.body if RUBY_VERSION == '1.9.3'
       @tokens = parse_tokens(data)
     end
-  
-  
+
+
     private
-    
+
     # Parse the authentication tokens out of the response and makes them available as a hash
     #
     # tokens[:auth] => Google requires this for every request (added to HTTP headers on GET requests)
     # tokens[:sid]  => Not used
     # tokens[:lsid] => Not used
-    
+
     def parse_tokens(data)
       tokens = {}
       data.split("\n").each do |t|
@@ -48,6 +49,6 @@ module Gattica
       end
       return tokens
     end
-  
+
   end
 end

--- a/lib/gattica/engine.rb
+++ b/lib/gattica/engine.rb
@@ -158,6 +158,7 @@ module Gattica
         end
       end
 
+      data = response.body if RUBY_VERSION == '1.9.3'
       return data
     end
 

--- a/lib/gattica/exceptions.rb
+++ b/lib/gattica/exceptions.rb
@@ -2,6 +2,7 @@ module GatticaError
   # user errors
   class InvalidEmail < StandardError; end;
   class InvalidPassword < StandardError; end;
+  class InvalidPkcs12Path < StandardError; end;
   # authentication errors
   class CouldNotAuthenticate < StandardError; end;
   class NoLoginOrToken < StandardError; end;


### PR DESCRIPTION
The old authenticate way "ClientLogin" is officially deprecated. Here is the story: https://developers.google.com/identity/protocols/AuthForInstalledApps.

We using the `gattica` gem in many places with Qor2. To fix this problem, we made it support Oauth2 way for authenticate. 
